### PR TITLE
Add grab mode for moving windows

### DIFF
--- a/README
+++ b/README
@@ -53,6 +53,11 @@ Scrolling:
 
 Or press T to toggle scrolling mode, so you don't have to hold G at all.
 
+Grab mode:
+
+- Press Tab to toggle grab mode.
+- When active, use h/j/k/l to move the frontmost window.
+
 Changing mouse speed:
 
 - Holding Shift: slower speed


### PR DESCRIPTION
## Summary
- add Grab mode toggled with `Tab`
- move front window with `h`/`j`/`k`/`l` when Grab mode is active
- show Grab status in overlay and adjust color
- document Grab mode in README

## Testing
- `cargo check` *(fails: failed to fetch git dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686ffed33ee4832795c8a806bdbd3524